### PR TITLE
Add Bayesian blocks discretization

### DIFF
--- a/src/Discretizers.jl
+++ b/src/Discretizers.jl
@@ -22,6 +22,7 @@ export
     DiscretizeMODL_Optimal,
     DiscretizeMODL_Greedy,
     DiscretizeMODL_PostGreedy,
+    DiscretizeBayesianBlocks,
 
     # sampling methods
     AbstractSampleMethod,
@@ -65,6 +66,7 @@ include("hybrid_discretizer.jl")
 include("disc_uniformwidth.jl")
 include("disc_uniformcount.jl")
 include("disc_MODL.jl")
+include("disc_bayesianblocks.jl")
 
 
 end # module

--- a/test/test_disc_bayesianblocks.jl
+++ b/test/test_disc_bayesianblocks.jl
@@ -1,0 +1,5 @@
+@test array_matches(binedges(DiscretizeBayesianBlocks(), [1.0,2.0,3.0,4.0,5.0,6.0]), [1.0, 6.0], 1e-8)
+@test array_matches(binedges(DiscretizeBayesianBlocks(), [6.0,2.0,30.0,4.0,1.0,1.0]), [1.0, 1.5, 30.0], 1e-8)
+
+@test binedges(DiscretizeBayesianBlocks(), [1,2,3,4,5,6]) == [1.0, 6.0]
+@test binedges(DiscretizeUniformCount(), [1,2,2,2,3]) == [1.0, 1.5, 30.0]


### PR DESCRIPTION
Add new Bayesian blocks linear discretizer. Bayesian blocks is
adaptive so doesn't accept a number of bins; instead it estimates
the optimal number of bins.

This is a simple implementation, with hard-coded fitness function
and prior, which could be made more generic in the future. The
algorithm can work with different data modes, but here only the
mode suitable for histograms is implemented.
