### PR TITLE
get_discretization_counts for multidimensional data

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -19,15 +19,14 @@ function get_discretization_counts(disc::AbstractDiscretizer, data::AbstractArra
 end
 
 function get_discretization_counts{N, D, T<:AbstractDiscretizer{N, D}}(discs::Vector{T}, data::AbstractMatrix{N})
-    m = size(data, 1)
-    n = size(data, 2)
-    @assert length(discs) == n
+    nobservations, ndimensions = size(data)
+    @assert length(discs) == ndimensions
     
     nbins = Tuple(nlabels.(discs))
     counts = zeros(Int, nbins)
-    for i in 1:m  # for each data point
-        binaddress = zeros(D, n)
-        for j in 1:n  # for each dimension
+    for i in 1:nobservations  # for each data point
+        binaddress = zeros(D, ndimensions)
+        for j in 1:ndimensions  # for each dimension
             binaddress[j] = encode(discs[j], data[i, j])
         end
         counts[binaddress...] += 1

--- a/src/common.jl
+++ b/src/common.jl
@@ -18,6 +18,24 @@ function get_discretization_counts(disc::AbstractDiscretizer, data::AbstractArra
     counts
 end
 
+function get_discretization_counts{N, D, T<:AbstractDiscretizer{N, D}}(discs::Vector{T}, data::AbstractMatrix{N})
+    m = size(data, 1)
+    n = size(data, 2)
+    @assert length(discs) == n
+    
+    nbins = Tuple(nlabels.(discs))
+    counts = zeros(Int, nbins)
+    for i in 1:m  # for each data point
+        binaddress = zeros(D, n)
+        for j in 1:n  # for each dimension
+            binaddress[j] = encode(discs[j], data[i, j])
+        end
+        counts[binaddress...] += 1
+    end
+    
+    counts
+end
+
 function get_histogram_plot_arrays{R<:Real, I<:Integer}(binedges::Vector{R}, counts::AbstractVector{I})
     n = length(binedges)
     n == length(counts)+1 || error("binedges must have exactly one more entry than counts!")

--- a/test/test_common.jl
+++ b/test/test_common.jl
@@ -1,2 +1,17 @@
 
 @test get_discretization_counts(LinearDiscretizer([0.0,1.0,2.0]), [0.5,0.5,0.5,1.5,1.5]) == [3,2]
+
+# Test for multidimensional discretization
+disc1 = LinearDiscretizer([0.0, 1.0, 2.0])
+disc2 = LinearDiscretizer([2.0, 3.0, 4.0, 5.0])
+data = [0.5 2.5
+        0.5 2.5
+        0.5 3.5
+        0.5 4.5
+        1.5 2.5
+        1.5 3.5
+        1.5 3.5
+        1.5 3.5]
+counts = [2 1 1
+          1 3 0]
+@test get_discretization_counts([disc1, disc2], data) == counts


### PR DESCRIPTION
I found myself using your package with multidimensional data, and in doing so I extended the `get_discretization_counts` function.
The extended version takes a vector of _n_ discretizers, and an _m_ x _n_ matrix of data (so _n_ is the dimensionality of the problem and _m_ the number of data points). It returns an _n_-dimensional array of counts. 

The hard part of multidimensional discretization seems to be choosing the discretization algorithms, so this may not be useful in the end. But I figured that I would let you decide on whether this belongs in Discretizers by itself :)