### PR TITLE
Removed dictionaries from LinearDiscretizer, added bincenter

### DIFF
--- a/src/Discretizers.jl
+++ b/src/Discretizers.jl
@@ -51,7 +51,8 @@ export
 
     # linear discretizer
     totalwidth,        # total width of set, max-mina
-    bincenters         # Vector{Float64} list of bin centers
+    bincenters,        # Vector{Float64} list of bin centers
+    bincenter          # Float64 center of a particular bin
 
 ### source files
 

--- a/src/disc_MODL.jl
+++ b/src/disc_MODL.jl
@@ -1,4 +1,5 @@
 using DataStructures
+using SpecialFunctions # for logfactorial
 
 abstract type DiscretizeMODL <: DiscretizationAlgorithm end
 
@@ -39,13 +40,13 @@ function MODL_value2_oneintval(
     n = length(continuous_ij)
     J = length(class_uniq)
 
-    first_part = lfactorial(n+J-1) - lfactorial(J-1) - lfactorial(n)
-    second_part = lfactorial(n)
-    # Note(Yi-Chun): lfactorial(n) is log(n!)
+    first_part = logfactorial(n+J-1) - logfactorial(J-1) - logfactorial(n)
+    second_part = logfactorial(n)
+    # Note(Yi-Chun): logfactorial(n) is log(n!)
 
     for J_index = 1:J
             n_J = count(x->x==class_uniq[J_index],class_value_ij)
-            second_part = second_part - lfactorial(n_J)
+            second_part = second_part - logfactorial(n_J)
     end
 
     return first_part+second_part
@@ -101,7 +102,7 @@ function optimal_result(
     full_length_k_intval = copy(Disc_ijk_MODL_value[n,:])
 
     for l = 1:n
-        full_length_k_intval[l] += lfactorial(n+l-1) - lfactorial(l-1) - lfactorial(n)
+        full_length_k_intval[l] += logfactorial(n+l-1) - logfactorial(l-1) - logfactorial(n)
     end
 
     desired_intval_number = argmin(full_length_k_intval)
@@ -135,12 +136,12 @@ function merge_adj_intval(
     n_A = sum(A_distr)
     n_B = sum(B_distr)
 
-    Delta = lfactorial(n_A+n_B+J-1) + lfactorial(J-1) - lfactorial(n_A+J-1) - lfactorial(n_B+J-1)
+    Delta = logfactorial(n_A+n_B+J-1) + logfactorial(J-1) - logfactorial(n_A+J-1) - logfactorial(n_B+J-1)
 
     for j = 1:J
         n_A_J = A_distr[j]
         n_B_J = B_distr[j]
-        Delta = Delta - lfactorial(n_A_J+n_B_J) + lfactorial(n_A_J) + lfactorial(n_B_J)
+        Delta = Delta - logfactorial(n_A_J+n_B_J) + logfactorial(n_A_J) + logfactorial(n_B_J)
     end
     Delta
 end
@@ -167,7 +168,7 @@ function greedy_merge_index(
     adj_for_intval = Dict()
     # Note(Yi-Chun): This dictionary contains the two adjacent interval for interval i
 
-    MODL = log(n) + lfactorial(2n-1) - lfactorial(n-1) - lfactorial(n) + n*log(J-1)
+    MODL = log(n) + logfactorial(2n-1) - logfactorial(n-1) - logfactorial(n) + n*log(J-1)
     # Note(Yi-Chun): Intial MODL when each attribute is treated as a single bin
 
     for i = 1:n-1
@@ -375,10 +376,10 @@ function methods_split(continuous,class_value,distr,i,j,uniq_class,I)
         distr_A[something(findfirst(isequal(class_ij[n_A_end]), uniq_class),0)] += 1
         distr_B = distr_ij - distr_A
 
-        Del = lfactorial(n_A_end+J-1)+lfactorial(n-n_A_end+J-1)-lfactorial(n+J-1)-lfactorial(J-1)
+        Del = logfactorial(n_A_end+J-1)+logfactorial(n-n_A_end+J-1)-logfactorial(n+J-1)-logfactorial(J-1)
 
         for j = 1:J
-            Del += lfactorial(distr_A[j]+distr_B[j])-lfactorial(distr_A[j])-lfactorial(distr_B[j])
+            Del += logfactorial(distr_A[j]+distr_B[j])-logfactorial(distr_A[j])-logfactorial(distr_B[j])
         end
 
 
@@ -409,11 +410,11 @@ function methods_merge(
     J = length(B_distr)
     n_A = sum(A_distr)
     n_B = sum(B_distr)
-    Delta = lfactorial(n_A+n_B+J-1) + lfactorial(J-1) - lfactorial(n_A+J-1) - lfactorial(n_B+J-1)
+    Delta = logfactorial(n_A+n_B+J-1) + logfactorial(J-1) - logfactorial(n_A+J-1) - logfactorial(n_B+J-1)
     for j = 1:J
         n_A_J = A_distr[j]
         n_B_J = B_distr[j]
-        Delta = Delta - lfactorial(n_A_J+n_B_J) + lfactorial(n_A_J) + lfactorial(n_B_J)
+        Delta = Delta - logfactorial(n_A_J+n_B_J) + logfactorial(n_A_J) + logfactorial(n_B_J)
     end
     Delta += log((I-1)/(N+I-1))
     return Delta
@@ -515,7 +516,7 @@ function uncondi_greedy_merge_index(
     distr_in_intval = Dict()
     adj_for_intval = Dict()
 
-    MODL = log(n) + lfactorial(2n-1) - lfactorial(n-1) - lfactorial(n) + n*log(J-1)
+    MODL = log(n) + logfactorial(2n-1) - logfactorial(n-1) - logfactorial(n) + n*log(J-1)
 
     total_distrib = zeros(Int64,J)
 

--- a/src/hybrid_discretizer.jl
+++ b/src/hybrid_discretizer.jl
@@ -76,5 +76,6 @@ totalwidth(disc::HybridDiscretizer) = totalwidth(disc.lin)
 
 nlabels(disc::HybridDiscretizer) = disc.lin.nbins + nlabels(disc.cat)
 bincenters(disc::HybridDiscretizer) = bincenters(disc.lin)
+bincenter(disc::HybridDiscretizer, i) = bincenter(disc.lin, i)
 binwidth(disc::HybridDiscretizer{N,D}, d::D) where {N<:AbstractFloat,D} = binwidth(disc.lin, d)
 binwidths(disc::HybridDiscretizer{N,D}) where {N<:AbstractFloat,D} = binwidths(disc.lin)

--- a/src/linear_discretizer.jl
+++ b/src/linear_discretizer.jl
@@ -22,33 +22,10 @@ TODO(tim):
 struct LinearDiscretizer{N<:Real, D<:Integer} <: AbstractDiscretizer{N,D}
     binedges :: Vector{N}   # list of bin edges, sorted smallest to largest
     nbins    :: Int
-    i2d      :: Dict{Int,D} # maps bin index to discrete label
-    d2i      :: Dict{D,Int} # maps discrete label to bin index
-
     force_outliers_to_closest :: Bool # if true, real values outside of the bin ranges will be forced to the nearest bin, otherwise will throw an error
 end
 
-function LinearDiscretizer( binedges::Vector{N}, i2d::Dict{Int,D};
-    force_outliers_to_closest::Bool = DEFAULT_LIN_DISC_FORCE_OUTLIERS_TO_CLOSEST ) where {N<:Real, D<:Integer}
-
-    length(binedges) > 1 || error("bin edges must contain at least 2 values")
-
-    if N <: AbstractFloat # continuous values
-        findfirst(i->binedges[i-1] ≥ binedges[i], 2:length(binedges)) == nothing ||
-            error("Bin edges must be sorted in increasing order")
-    else # for integers, bins of unit width require repeated values
-        (findfirst(i->binedges[i-1] ≥ binedges[i], 2:length(binedges)-1) == nothing &&
-         findfirst(i->binedges[i-1] > binedges[i], 2:length(binedges)) == nothing ) ||
-            error("Bin edges must be sorted in increasing order")
-    end
-
-    all(haskey(i2d, i) for i in 1 : length(binedges)-1) || error("i2d must contain all necessary keys")
-
-    d2i = Dict{D,Int}(v => k for (k,v) in i2d)
-
-    return LinearDiscretizer{N,D}(binedges, length(binedges)-1, i2d, d2i, force_outliers_to_closest)
-end
-function LinearDiscretizer(binedges::Vector{N}, ::Type{D} = Int;
+function LinearDiscretizer(binedges::AbstractArray{N}, ::Type{D} = Int;
     force_outliers_to_closest::Bool = DEFAULT_LIN_DISC_FORCE_OUTLIERS_TO_CLOSEST ) where {N<:Real, D<:Integer}
 
     length(binedges) > 1 || error("bin edges must contain at least 2 values")
@@ -62,13 +39,9 @@ function LinearDiscretizer(binedges::Vector{N}, ::Type{D} = Int;
             error("Bin edges must be sorted in increasing order")
     end
 
-    i2d = Dict{Int,D}(i => convert(D, i) for i in 1 : length(binedges)-1)
+    nbins = length(binedges)-1
 
-    return LinearDiscretizer(binedges,i2d,force_outliers_to_closest=force_outliers_to_closest)
-end
-function LinearDiscretizer(arr::AbstractVector{N}, ::Type{D}=Int;
-    force_outliers_to_closest::Bool = DEFAULT_LIN_DISC_FORCE_OUTLIERS_TO_CLOSEST) where {N<:Real, D<:Integer}
-    LinearDiscretizer(convert(Vector{N}, arr), D, force_outliers_to_closest=force_outliers_to_closest)
+    return LinearDiscretizer{N,D}(convert(Vector{N}, binedges), nbins, force_outliers_to_closest)
 end
 
 function supports_encoding(ld::LinearDiscretizer{N,D}, x::N) where {N<:Real,D<:Integer}
@@ -84,9 +57,9 @@ function encode(ld::LinearDiscretizer{N,D}, x::N) where {N<:Real,D<:Integer}
     !isnan(x) || error("cannot encode NaN values")
 
     if x < ld.binedges[1]
-        return ld.force_outliers_to_closest ? ld.i2d[1] : throw(BoundsError())
+        return ld.force_outliers_to_closest ? convert(D,1) : throw(BoundsError())
     elseif x > ld.binedges[end]
-        return ld.force_outliers_to_closest ? ld.i2d[ld.nbins] : throw(BoundsError())
+        return ld.force_outliers_to_closest ? convert(D,ld.nbins) : throw(BoundsError())
     else
 
         # run bisection search
@@ -102,7 +75,7 @@ function encode(ld::LinearDiscretizer{N,D}, x::N) where {N<:Real,D<:Integer}
                 a, va = c, vc
             end
         end
-        return ld.i2d[a]
+        return convert(D,a)
     end
 end
 encode(ld::LinearDiscretizer{N,D}, x) where {N<:Real,D<:Integer} = encode(ld, convert(N, x))::D
@@ -117,23 +90,20 @@ The default is SampleUniform, which uniformly samples from the bin.
 SampleBinCenter returns the bin's center value.
 """
 function decode(ld::LinearDiscretizer{N,D}, d::D, ::SampleUniform) where {N<:AbstractFloat,D<:Integer}
-    ind = ld.d2i[d]
-    lo  = ld.binedges[ind]
-    hi  = ld.binedges[ind+1]
+    lo  = ld.binedges[d]
+    hi  = ld.binedges[d+1]
     convert(N, lo + rand()*(hi-lo))
 end
 function decode(ld::LinearDiscretizer{N,D}, d::D, ::SampleBinCenter) where {N<:AbstractFloat,D<:Integer}
-    ind = ld.d2i[d]
-    lo  = ld.binedges[ind]
-    hi  = ld.binedges[ind+1]
+    lo  = ld.binedges[d]
+    hi  = ld.binedges[d+1]
     convert(N, (hi + lo)/2)
 end
 decode(ld::LinearDiscretizer{N,D}, d::D) where {N<:AbstractFloat,D<:Integer} = decode(ld, d, SAMPLE_UNIFORM)
 
 function decode(ld::LinearDiscretizer{N,D}, d::D, ::SampleUniform) where {N<:Integer,D<:Integer}
-    ind = ld.d2i[d]
-    lo  = ld.binedges[ind]
-    hi  = ld.binedges[ind+1]
+    lo  = ld.binedges[d]
+    hi  = ld.binedges[d+1]
     if hi != ld.binedges[end]
         retval = rand(lo:hi-1)::Int
     else
@@ -142,9 +112,8 @@ function decode(ld::LinearDiscretizer{N,D}, d::D, ::SampleUniform) where {N<:Int
     convert(N, retval)
 end
 function decode(ld::LinearDiscretizer{N,D}, d::D, ::SampleBinCenter) where {N<:Integer,D<:Integer}
-    ind = ld.d2i[d]
-    lo = ld.binedges[ind]
-    hi = ld.binedges[ind+1]
+    lo = ld.binedges[d]
+    hi = ld.binedges[d+1]
     convert(N, div(lo+hi,2))
 end
 decode(ld::LinearDiscretizer{N,D}, d::D) where {N<:Integer,D<:Integer} = decode(ld, d, SAMPLE_UNIFORM)
@@ -168,15 +137,13 @@ function Base.extrema(ld::LinearDiscretizer{N,D}) where {N<:Real,D<:Integer}
     return (lo, hi)
 end
 function Base.extrema(ld::LinearDiscretizer{N,D}, d::D) where {N<:AbstractFloat,D<:Integer}
-    ind = ld.d2i[d]
-    lo  = ld.binedges[ind]
-    hi  = ld.binedges[ind+1]
+    lo  = ld.binedges[d]
+    hi  = ld.binedges[d+1]
     return (lo, hi)
 end
 function Base.extrema(ld::LinearDiscretizer{N,D}, d::D) where {N<:Integer,D<:Integer}
-    ind = ld.d2i[d]
-    lo  = ld.binedges[ind]
-    hi  = ld.binedges[ind+1]
+    lo  = ld.binedges[d]
+    hi  = ld.binedges[d+1]
     if hi == ld.binedges[end]
         (lo, hi)
     else

--- a/src/linear_discretizer.jl
+++ b/src/linear_discretizer.jl
@@ -166,5 +166,14 @@ function bincenters(ld::LinearDiscretizer{N,D}) where {N<:Integer,D<:Integer}
     retval[end] = 0.5(ld.binedges[end] + ld.binedges[end-1])
     retval
 end
+bincenter(ld::LinearDiscretizer{N}, i) where N <: AbstractFloat = 0.5*(ld.binedges[i+1] + ld.binedges[i])
+function bincenter(ld::LinearDiscretizer{N}, i) where N <: Integer
+    if i == length(ld.binedges)-1
+        return 0.5*(ld.binedges[end] + ld.binedges[end-1])
+    else
+        return 0.5*(ld.binedges[i+1]-1 + ld.binedges[i])
+    end
+end
+
 binwidth(ld::LinearDiscretizer{N,D}, d::D) where {N<:Real,D<:Integer} = ld.binedges[d+1] - ld.binedges[d]
 binwidths(ld::LinearDiscretizer{N,D}) where {N<:Real,D<:Integer} = ld.binedges[2:end] - ld.binedges[1:end-1]

--- a/test/test_hybrid_discretizer.jl
+++ b/test/test_hybrid_discretizer.jl
@@ -33,6 +33,7 @@ disc = datalineardiscretizer([0.0,1.0,2.0])
 
 @test nlabels(disc) == 3
 @test array_matches(bincenters(disc), [0.5,1.5])
+@test isapprox([bincenter(disc, i) for i in 1:nlabels(disc.lin)], bincenters(disc))
 @test isapprox(binwidth(disc, 1), 1.0)
 @test isapprox(binwidth(disc, 2), 1.0)
 @test array_matches(binwidths(disc), [1.0,1.0])

--- a/test/test_linear_discretizer.jl
+++ b/test/test_linear_discretizer.jl
@@ -28,8 +28,8 @@ ld = LinearDiscretizer([0.0,0.5,1.0])
 @test isapprox(decode(ld, 1, SAMPLE_BIN_CENTER), 0.25)
 @test isapprox(decode(ld, 2, SAMPLE_BIN_CENTER), 0.75)
 
-@test_throws KeyError decode(ld,  0)
-@test_throws KeyError decode(ld,  3)
+@test_throws BoundsError decode(ld,  0)
+@test_throws BoundsError decode(ld,  3)
 @test 0.5 ≤ decode(ld, 2 % UInt8) ≤ 1.0
 mat = decode(ld, [2 1; 1 2])
 @test 0.5 ≤ mat[1,1] ≤ 1.0
@@ -95,8 +95,8 @@ ld = LinearDiscretizer([0,10,20])
 @test decode(ld, 1, SAMPLE_BIN_CENTER) == 5
 @test decode(ld, 2, SAMPLE_BIN_CENTER) == 15
 
-@test_throws KeyError decode(ld,  0)
-@test_throws KeyError decode(ld,  3)
+@test_throws BoundsError decode(ld,  0)
+@test_throws BoundsError decode(ld,  3)
 @test 10 ≤ decode(ld, 2 % UInt8) ≤ 20
 mat = decode(ld, [2 1; 1 2])
 @test 10 ≤ mat[1,1] ≤ 20

--- a/test/test_linear_discretizer.jl
+++ b/test/test_linear_discretizer.jl
@@ -43,6 +43,8 @@ mat = decode(ld, [2 1; 1 2])
 
 @test nlabels(ld) == 2
 @test array_matches(bincenters(ld), [0.25,0.75], 1e-8)
+@test isapprox([bincenter(ld, i) for i in 1:nlabels(ld)], bincenters(ld))
+
 
 @test encoded_type(ld) == Int
 @test decoded_type(ld) == Float64
@@ -110,6 +112,7 @@ mat = decode(ld, [2 1; 1 2])
 
 @test nlabels(ld) == 2
 @test array_matches(bincenters(ld), [4.5,15], 1e-8)
+@test isapprox([bincenter(ld, i) for i in 1:nlabels(ld)], bincenters(ld))
 
 @test encoded_type(ld) == Int
 @test decoded_type(ld) == Int


### PR DESCRIPTION
Changes discussed in #24 and #23 

I decided to completely get rid of the dicts. Since D was already limited to be an Integer anyways, I think convert is actually the best way to support different key types. Moreover, if people want to use their own dicts/arrays on top of this to support mapping to some other type, that should not be too hard.

I also had to fix the lfactorial deprecation warning so that the tests would run in reasonable time.

Finally, there is one side effect of removing the dicts - if the user tries to decode an out-of-bounds key, a BoundsError is thrown instead of a KeyError. This seems ok to me.

This will directly affect some of the code I am using for my class, so I hope we can merge it ASAP. When it is done merging, can I add upper bounds to the dependency compats and tag and register v3.2.0?