### PR TITLE
Updating Project.toml to allow DataStructures 0.18

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,9 +10,9 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-DataStructures = "0.10,0.11,0.12,0.13,0.14,0.15,0.16,0.17" # tested on 0.10 and 0.17
-SpecialFunctions = "0,1" # was >= 0.6, tested with 0.10. Every new release seems to increment by 0.1
-StatsBase = "0,1" # was >= 0.24, tested with 0.32. Every new release seems to increment by 0.1
+DataStructures = "0.10,0.11,0.12,0.13,0.14,0.15,0.16,0.17,0.18"
+SpecialFunctions = "0,1"
+StatsBase = "0,1"
 julia = "0.7,1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -11,8 +11,8 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 DataStructures = "0.10,0.11,0.12,0.13,0.14,0.15,0.16,0.17,0.18"
-SpecialFunctions = "0,1"
-StatsBase = "0,1"
+SpecialFunctions = "0,1" # was >= 0.6, tested with 0.10. Every new release seems to increment by 0.1
+StatsBase = "0,1" # was >= 0.24, tested with 0.32. Every new release seems to increment by 0.1
 julia = "0.7,1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-DataStructures = "0.10,0.11,0.12,0.13,0.14,0.15,0.16,0.17,0.18"
+DataStructures = "0.10,0.11,0.12,0.13,0.14,0.15,0.16,0.17,0.18" # tested on 0.10, 0.17 and 0.18
 SpecialFunctions = "0,1" # was >= 0.6, tested with 0.10. Every new release seems to increment by 0.1
 StatsBase = "0,1" # was >= 0.24, tested with 0.32. Every new release seems to increment by 0.1
 julia = "0.7,1"


### PR DESCRIPTION
All tests pass when using DataStructures 0.18.