### PR TITLE
support specialfunctions 2.x

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 DataStructures = "0.10,0.11,0.12,0.13,0.14,0.15,0.16,0.17,0.18,0.19"
-SpecialFunctions = "0.6,0.7,0.8,0.9,1.0,1.1,1.2" # was >= 0.6, tested with 0.10. Every new release seems to increment by 0.1
+SpecialFunctions = "0.6,0.7,0.8,0.9,1.0,1.1,1.2,2" # was >= 0.6, tested with 0.10. Every new release seems to increment by 0.1
 StatsBase = "0.24,0.25,0.26,0.27,0.28,0.29,0.30,0.31,0.32,0.33" # was >= 0.24, tested with 0.33. Every new release seems to increment by 0.1
 julia = "0.7,1"
 


### PR DESCRIPTION
The only breaking change in SpecialFunctions 2.0 [was deleting](https://github.com/JuliaMath/SpecialFunctions.jl/pull/297) the `factorial(x::Real) = gamma(x+1)` function, and since you don't use `factorial` this shouldn't affect you.